### PR TITLE
Use import type instead of import

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ npm install type-fest
 ## Usage
 
 ```ts
-import {Except} from 'type-fest';
+import type {Except} from 'type-fest';
 
 type Foo = {
 	unicorn: string;


### PR DESCRIPTION
In some edge cases Webpack would put into output file type-fest as a module which would fail during runtime with a message "Cannot load module 'type-fest'". Using `import type` helps Webpack and strips type-fest from the output file. Since TS >= 4.2 is required to use type-fest and 'import-type' is introduced in 3.8, perhaps suggested way of importing types from type-fest should be with 'import type'?